### PR TITLE
Add support for floating point boundaries

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -27,6 +27,12 @@
     </style>
 </head>
 <body>
+    <input type="range" min="10" max="11" step="0.1" value="10.2" data-rangeslider>
+
+    <br>
+    <br>
+    <br>
+
     <input type="range" min="10" max="100" step="1" value="50" data-rangeslider>
 
     <br>

--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -108,10 +108,10 @@
         }
 
         this.identifier = 'js-' + pluginName + '-' + +new Date();
-        this.value      = parseInt(this.$element[0].value) || 0;
-        this.min        = parseInt(this.$element[0].getAttribute('min')) || 0;
-        this.max        = parseInt(this.$element[0].getAttribute('max')) || 0;
-        this.step       = parseInt(this.$element[0].getAttribute('step')) || 1;
+        this.value      = parseFloat(this.$element[0].value) || 0;
+        this.min        = parseFloat(this.$element[0].getAttribute('min')) || 0;
+        this.max        = parseFloat(this.$element[0].getAttribute('max')) || 0;
+        this.step       = parseFloat(this.$element[0].getAttribute('step')) || 1;
         this.$range     = $('<div class="' + this.options.rangeClass + '" />');
         this.$fill      = $('<div class="' + this.options.fillClass + '" />');
         this.$handle    = $('<div class="' + this.options.handleClass + '" />');
@@ -205,7 +205,7 @@
         value = this.getValueFromPosition(left);
 
         // Snap steps
-        if (this.step > 1) {
+        if (this.step !== 1) {
             value = Math.ceil((value) / this.step ) * this.step;
             left = this.getPositionFromValue(value);
         }
@@ -249,7 +249,7 @@
     Plugin.prototype.getValueFromPosition = function(pos) {
         var percentage, value;
         percentage = ((pos) / (this.maxHandleX)) * 100;
-        value = Math.ceil(((percentage/100) * (this.max - this.min)) + this.min);
+        value = this.step * Math.ceil((((percentage/100) * (this.max - this.min)) + this.min) / this.step);
 
         return value;
     };


### PR DESCRIPTION
The linting is currently failing on `master`, but as far as I can tell, this patch does not introduce any new errors.

Commit message:

> According to the W3C's documentation of the `range` input type [1], the
> `min`, `max`, `step`, and `value` attributes may all be specified as
> floating point numbers.
> 
> [1] http://www.w3.org/TR/html-markup/input.range.html
