### PR TITLE
Expose a `cleanup` method

### DIFF
--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -130,15 +130,13 @@
         this.handleDown = $.proxy(this.handleDown, this);
         this.handleMove = $.proxy(this.handleMove, this);
         this.handleEnd  = $.proxy(this.handleEnd, this);
+        this.handleResize = debounce($.proxy(delay, null, $.proxy(this.update, this), 300));
 
         this.init();
 
         // Attach Events
-        var _this = this;
-        this.$window.on('resize' + '.' + pluginName, debounce(function() {
-            // Simulate resizeEnd event.
-            delay(function() { _this.update(); }, 300);
-        }, 20));
+
+        this.$window.on('resize' + '.' + pluginName, this.handleResize);
         this.$document.on(this.options.startEvent, '#' + this.identifier, this.handleDown);
     }
 
@@ -148,6 +146,12 @@
         if (this.onInit && typeof this.onInit === 'function') {
             this.onInit();
         }
+    };
+
+    // Remove event handlers bound to global objects
+    Plugin.prototype.cleanup = function() {
+        this.$window.off('resize' + '.' + pluginName, this.handleResize);
+        this.$document.off(this.options.startEvent, '#' + this.identifier, this.handleDown);
     };
 
     Plugin.prototype.update = function() {


### PR DESCRIPTION
Consumers should have a means to unbind handlers bound to global events.
This allows them to avoid memory leaks and prevents the accumulation of
meaningless event handlers for plugin instances that have been
destroyed.

In order to use this API, consumers will need to access the plugin
instance as it is attached to elements with jQuery's "data" API. Because
of this, the attribute name should be a formal committment of this
library and explicitly documented.
