### PR TITLE
Support in-memory initialization

### DIFF
--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -248,7 +248,7 @@
 
     Plugin.prototype.getValueFromPosition = function(pos) {
         var percentage, value;
-        percentage = ((pos) / (this.maxHandleX)) * 100;
+        percentage = ((pos) / (this.maxHandleX || 1)) * 100;
         value = Math.ceil(((percentage/100) * (this.max - this.min)) + this.min);
 
         return value;


### PR DESCRIPTION
When range input elements are created in memory, the value for
`maxHandleX` will be zero. This causes the value reported by the initial
"slide" event to be NaN.

```
$('<input type="range" min="0" max="1">').rangeslider({
  onSlide: function(pos, val) {
    // Number.isNaN(val) === true;
  }
});
```

Modify the value calculation to return 0 when `maxHandleX` is 0.
