### PR TITLE
Wrap 'use strict'

### DIFF
--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -1,5 +1,3 @@
-'use strict';
-
 (function(factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
@@ -13,6 +11,7 @@
         factory(jQuery);
     }
 }(function($) {
+    'use strict';
 
     /**
      * Range feature detection


### PR DESCRIPTION
`'use strict'` can bug other js files when concatenated, I moved it into the function to avoid this
