### PR TITLE
Patch 'drag to outside window' bug

### DIFF
--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -245,7 +245,7 @@
     };
 
     Plugin.prototype.getRelativePosition = function(node, e) {
-        return (e.pageX || e.originalEvent.clientX || e.originalEvent.touches[0].clientX || e.currentPoint.x) - this.getPositionFromNode(node);
+        return (e.pageX || e.originalEvent.clientX || (e.originalEvent.touches && e.originalEvent.touches[0].clientX) || (e.currentPoint && e.currentPoint.x) || 0) - this.getPositionFromNode(node);
     };
 
     Plugin.prototype.getPositionFromValue = function(value) {


### PR DESCRIPTION
Noticed a bug when I dragged from the middle of the bar to outside the window.

Uncaught TypeError: Cannot read property '0' of undefined rangeslider.min.js:2
At: b.originalEvent.touches[0]
Fix: (b.originalEvent.touches && b.originalEvent.touches[0])

Did a similar fix for e.currentPoint.x and then added a fallback to 0 at the end in case none of them worked.
