### PR TITLE
Do not calculate position on hidden elements

### DIFF
--- a/dist/rangeslider.js
+++ b/dist/rangeslider.js
@@ -311,6 +311,8 @@
 
     Plugin.prototype.setPosition = function(pos) {
         var value, left;
+        
+        if (this.$element[0].offsetParent === null) { return false; }
 
         // Snapping steps
         value = this.getValueFromPosition(this.cap(pos, 0, this.maxHandleX));

--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -310,6 +310,8 @@
 
     Plugin.prototype.setPosition = function(pos) {
         var value, left;
+        
+        if (this.$element[0].offsetParent === null) { return false; }
 
         // Snapping steps
         value = this.getValueFromPosition(this.cap(pos, 0, this.maxHandleX));


### PR DESCRIPTION
If an slider is hidden on init, it will always set its min attribute as its value. This overwrites any default value that is set via the value attribute.

This commit will prevent a hidden element from calculating its position and instead rely on the defaults set. 

This will also prevent any the onSlide and onSlideEnd callbacks from being run on a hidden element - however if it's hidden, these wouldn't be trigger-able anyway!