### PR TITLE
Fix attributes NaN & falsey default value issue

### DIFF
--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -158,6 +158,18 @@
     }
 
     /**
+     * Returns the parsed float or the default if it failed.
+     *
+     * @param  {String}  str
+     * @param  {Number}  defaultValue
+     * @return {Number}
+     */
+    function tryParseFloat(str, defaultValue) {
+        var rtn = parseFloat(str);
+        return isNaN(rtn) ?  defaultValue : rtn;
+    }
+    
+    /**
      * Plugin
      * @param {String} element
      * @param {Object} options
@@ -240,10 +252,10 @@
         updateAttributes = updateAttributes || false;
 
         if (updateAttributes) {
-            this.min    = parseFloat(this.$element[0].getAttribute('min') || 0);
-            this.max    = parseFloat(this.$element[0].getAttribute('max') || 100);
-            this.value  = parseFloat(this.$element[0].value || this.min + (this.max-this.min)/2);
-            this.step   = parseFloat(this.$element[0].getAttribute('step') || 1);
+            this.min    = tryParseFloat(this.$element[0].getAttribute('min'), 0);
+            this.max    = tryParseFloat(this.$element[0].getAttribute('max'), 100);
+            this.value  = tryParseFloat(this.$element[0].value, this.min + (this.max-this.min)/2);
+            this.step   = tryParseFloat(this.$element[0].getAttribute('step'), 1);
         }
 
         this.handleWidth    = getDimension(this.$handle[0], 'offsetWidth');


### PR DESCRIPTION
Hey there,

I just had a spot of bother with this library. It seems that in FF when `<input type="range" max="" min="" value="10">` the parseFloat returned a NaN this then set the value to 50 later on. 

This PR fixes the NaN issue.