### PR TITLE
Doesn't work inside a display: none !important container

### DIFF
--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -161,7 +161,11 @@
                 inlineStyle[i] = hiddenParentNodes[i].style.cssText;
 
                 // visually hide
-                hiddenParentNodes[i].style.display = 'block';
+                if (hiddenParentNodes[i].style.setProperty) {
+                    hiddenParentNodes[i].style.setProperty('display', 'block', 'important');
+                } else {
+                    hiddenParentNodes[i].style.cssText += ';display: block !important';
+                }
                 hiddenParentNodes[i].style.height = '0';
                 hiddenParentNodes[i].style.overflow = 'hidden';
                 hiddenParentNodes[i].style.visibility = 'hidden';


### PR DESCRIPTION
Rangeslider doesn't work if it is initialized inside a hidden container where **display: none** has been forced with an **!important** declaration. This way to hide elements is used by Bootstrap, HTML5 Boilerplate, ...

```css
.hidden {
  display: none !important;
}
```
```html
<div class="hidden">
  <input type="range" />
</div>
```
This is because hiddenParentNodes[i].style.display = 'block' doesn't override class level important style. My fix correct this problem.