### PR TITLE
jquery compatibility based on >=

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "jquery": "^1.9.0"
+    "jquery": ">=1.9.0"
   },
   "devDependencies": {
     "crayola": "0.0.1",


### PR DESCRIPTION
This will avoid bringing jquery 1.x into a project that explicitly wants to use 2.x.