### PR TITLE
feat: Add onResize callback to get pos and value

### DIFF
--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -222,6 +222,7 @@
         this.onInit             = this.options.onInit;
         this.onSlide            = this.options.onSlide;
         this.onSlideEnd         = this.options.onSlideEnd;
+        this.onResize           = this.options.onResize;
         this.DIMENSION          = constants.orientation[this.orientation].dimension;
         this.DIRECTION          = constants.orientation[this.orientation].direction;
         this.DIRECTION_STYLE    = constants.orientation[this.orientation].directionStyle;
@@ -311,6 +312,10 @@
         }
 
         this.setPosition(this.position, triggerSlide);
+
+        if (this.onResize && typeof this.onResize === 'function') {
+            this.onResize(this.position, this.value);
+        }
     };
 
     Plugin.prototype.handleDown = function(e) {


### PR DESCRIPTION
on window resize, it would be nice to get back the new pos/value. This allows for "bubbles" to be attached on the slider and other elements aware of the slider's handles new location. 

Add new callback option of onResize to get this value.  
Having this issue happen on purpose in a new callback: https://github.com/andreruffert/rangeslider.js/issues/199
