### PR TITLE
Call onSlideEnd when slider value is change through API

### DIFF
--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -277,6 +277,10 @@
             var value = e.target.value,
                 pos = _this.getPositionFromValue(value);
             _this.setPosition(pos);
+
+            if (_this.onSlideEnd && typeof _this.onSlideEnd === 'function') {
+                _this.onSlideEnd(pos, _this.value);
+            }
         });
     }
 


### PR DESCRIPTION
The onSlideEnd function should be called after a change to the slider value from an API call.  An API call results in movement of the slider, which should result in a slide end event.  It is expected functionality that the handler be called so anything related to the slider value changing is properly updated.