### PR TITLE
Adds a new  option which sets the center of the fill bar at zero. Use…

### DIFF
--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -42,6 +42,7 @@
             horizontalClass: 'rangeslider--horizontal',
             verticalClass: 'rangeslider--vertical',
             fillClass: 'rangeslider__fill',
+            fillBeginsAtZero: false,
             handleClass: 'rangeslider__handle',
             startEvent: ['mousedown', 'touchstart', 'pointerdown'],
             moveEvent: ['mousemove', 'touchmove', 'pointermove'],
@@ -383,8 +384,31 @@
         value = this.getValueFromPosition(this.cap(pos, 0, this.maxHandlePos));
         newPos = this.getPositionFromValue(value);
 
+        // Fill style
+        var fillDimension, fillDirection;
+        if (this.options.fillBeginsAtZero === true && 0 >= this.min && 0 <= this.max) {
+            var zeroPos = this.getPositionFromValue(0) + this.grabPos;
+            if (this.orientation === 'horizontal' && value >= 0) {
+                fillDirection = zeroPos;
+                fillDimension = newPos - zeroPos + this.grabPos;
+            } else if (this.orientation === 'horizontal' && value < 0) {
+                fillDirection = newPos + this.grabPos;
+                fillDimension = zeroPos - newPos - this.grabPos;
+            } else if (this.orientation === 'vertical' && value >= 0) {
+                fillDirection = zeroPos;
+                fillDimension = newPos - zeroPos + this.grabPos;
+            } else {
+                fillDirection = newPos + this.grabPos;
+                fillDimension = zeroPos - newPos - this.grabPos;
+            }
+        } else {
+            fillDimension = zeroPos;
+            fillDirection = 0;
+        }
+
         // Update ui
-        this.$fill[0].style[this.DIMENSION] = (newPos + this.grabPos) + 'px';
+        this.$fill[0].style[this.DIMENSION] = fillDimension + 'px';
+        this.$fill[0].style[this.DIRECTION_STYLE] = fillDirection + 'px';
         this.$handle[0].style[this.DIRECTION_STYLE] = newPos + 'px';
         this.setValue(value);
 

--- a/src/rangeslider.js
+++ b/src/rangeslider.js
@@ -402,7 +402,7 @@
                 fillDimension = zeroPos - newPos - this.grabPos;
             }
         } else {
-            fillDimension = zeroPos;
+            fillDimension = newPos + this.grabPos;
             fillDirection = 0;
         }
 


### PR DESCRIPTION
This PR adds a new `fillBeginsAtZero` option which sets the center of the fill bar at zero.
It can be usefull when the values range from negative to positive. If needed, it should be possible to add another option in order to choose a different value than zero. Or maybe rename the first option to `fillBeginsAtValue` and make it accept a number instead of a boolean.

Anyway, a few examples:

![rangejs_horizontal](https://user-images.githubusercontent.com/9882128/67350054-ebdc1e80-f549-11e9-9df2-a14fa54a36af.png)

It also works when the negative and positive values are uneven:

![rangejs_horizontal_uneven](https://user-images.githubusercontent.com/9882128/67350100-057d6600-f54a-11e9-935d-ea6b9ac8e86d.png)

And it supports vertical orientation:

![rangejs_vertical](https://user-images.githubusercontent.com/9882128/67350108-0f9f6480-f54a-11e9-8f85-f9967d39f242.png)

(In these screenshots I added a ruler for clarity. Also, I forgot to disable my custom theme).


